### PR TITLE
feat: add adr 3 and 4

### DIFF
--- a/docs/architecture/decisions/001-documenting-architectural-decisions.md
+++ b/docs/architecture/decisions/001-documenting-architectural-decisions.md
@@ -1,14 +1,14 @@
 # ADR 1 - Documenting Architectural Decisions
 
-# Status
+## Status
 ✅ Accepted on 2025-04-28
 
-# Context
+## Context
 To ensure that significant architectural decisions are clear and accessible to all team members and the public, we need a way to document these design choices effectively.
 
 No one should be left wondering about the thought process behind our architectural decisions. This is essential for both current and future team members, as well as external collaborators who may contribute to the project in the future.
 
-# Decision
+## Decision
 We have decided to implement Architecture Decision Records (ADRs) to document significant architectural decisions, including those related to the a11yscore algorithm.
 
 Each ADR will be stored in the `docs/architecture/decisions` directory of this repository. The files will follow a consistent naming convention, with each ADR having a unique and increasing number, starting from 1.
@@ -23,7 +23,7 @@ The ADRs will adhere to a standard template consisting of the following sections
 
 Each ADR should be written in Markdown and kept within a maximum length of 1-2 pages.
 
-# Consequences
+## Consequences
 The introduction of ADRs will provide a structured approach to documenting architectural decisions. This clarity will facilitate understanding among current and future team members, as well as the public, regarding our design choices.
 
 Moreover, this format will make it easier for outside contributors to collaborate with us in the future, allowing them to discuss changes to the architecture using this standardized pattern.

--- a/docs/architecture/decisions/002-initial-technology-choices.md
+++ b/docs/architecture/decisions/002-initial-technology-choices.md
@@ -1,14 +1,14 @@
 # ADR 2 - Initial Technology Choices
 
-# Status
+## Status
 ✅ Accepted on 2025-04-28
 
-# Context
+## Context
 To build a robust and scalable system, we first need to decide on our technology stack.
 
 We previously built a prototype of the algorithm to assess its feasibility. During this proof-of-concept phase, we found that the best publicly accessible data on accessibility of public spaces is available on [OpenStreetMap](https://wiki.openstreetmap.org/) (OSM).
 
-# Decision
+## Decision
 We will use data from OSM and adopt [OSM tags](https://wiki.openstreetmap.org/wiki/Tags) as the standard input data format for the a11yscore algorithm. OSM tags provide a well-defined standard for describing public spaces and their accessibility. We also considered using the [a11yjson](https://sozialhelden.github.io/a11yjson/) standard but decided against it due to the significant overhead in terms of performance and complexity that would arise from converting data from sources like OSM to a11yjson.
 
 We will import data from all relevant data sources (initially only OSM) into a [PostgreSQL](https://www.postgresql.org/) database. This allows for efficient data analysis using plain SQL queries, leveraging the [PostGIS extension](https://postgis.net/) to support geospatial queries. PostgreSQL is a performant, well-supported, and widely used technology that enables optimized computationally intensive operations at the database layer. We also considered using big-data analysis tools like [Apache Spark](https://spark.apache.org/) but decided against it due to our lack of experience with these systems. Moreover, using a simpler technology like SQL makes it easier for others and the public to understand the algorithm's implementation and contribute to it. We also considered existing solutions that allow querying OSM data directly, such as the [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API) or the [Ohsome API](https://wiki.openstreetmap.org/wiki/Ohsome_API). These are suited for smaller queries and/or datasets and does not scale well enough for our needs.
@@ -17,7 +17,7 @@ For importing OSM data into the PostgreSQL database, we will use [imposm3](https
 
 For programming the algorithm, we will use [TypeScript](https://www.typescriptlang.org/). We chose TypeScript because it is a modern language with strong typing and wide adoption. Although we considered alternatives like [Rust](https://www.rust-lang.org/) and [Go](https://go.dev/) due to their performance benefits, we decided against them due to their steep learning curve, lesser adoption, and for uniformity with our existing tech stack. Since computational intensive parts of the algorithm are executed on the database level using SQL queries, the performance of the programming language itself is less critical. We are optimistic that TypeScript, combined with a fast and modern runtime, will be performant enough for our needs. By using TypeScript, we also enable more developers and the public to understand the algorithm's implementation and contribute to it.
 
-# Consequences
+## Consequences
 Any additional data sources we wish to include in the future must either be converted to OSM tags or added to OpenStreetMap to be used by the algorithm. We prefer the latter option, hoping to convince stakeholders to publish their data openly on OSM, benefiting more projects that rely on open data besides a11yscore.
 
 Importing the entire OSM planet file into a PostgreSQL database using imposm3 requires significant disk space, memory, and computational resources, making it inefficient for machines commonly used for development. We will need to develop tools and processes to work efficiently with the a11yscore algorithm in the future.

--- a/docs/architecture/decisions/003-algorithm-structure-and-data-model.md
+++ b/docs/architecture/decisions/003-algorithm-structure-and-data-model.md
@@ -1,0 +1,29 @@
+# ADR 3 - Algorithm Structure and Data Model
+
+## Status
+✅ Accepted on 2025-06-17
+
+## Context
+The a11y-Score project aims to calculate a score for regions that reflects the accessibility of the physical world and provide concrete actionable tasks organizations and governments can take to improve accessibility in their area.
+
+To achieve this, we need to define a structure and data model that is suitable for calculating accessibility scores and providing actionable insights. From decades of research, we know most typical and niche accessibility requirements for domains like gastronomy, sanitary facilities, hotels, or public transit. So the goal of the structure and data model is to break down the accessibility of the physical world into such small parts, that can then be evaluated properly.
+
+## Decision
+We will use the [United Nations Sustainable Development Goals (SDGs)](https://sdgs.un.org/goals) as a foundational layer. This helps us to align our evaluation criteria with global standards and priorities, ensuring that our work contributes to broader societal goals.
+
+We will define broad **CATEGORIES** such as e.g. "Mobility", "Food & Drinks" or "Culture" that align closely and are related to one or more SDGs. These broad categories will be further divided into more specific sub categories, such as e.g. "Public Transport", "Restaurants", "Museums". We will create a hierarchical structure of categories and sub categories to break down the accessibility of the physical world to small manageable and evaluable parts.
+
+We will define individual **CRITERIA** such as e.g. "accessible by wheelchair", "has a tactile guidance system" or "has a digital menu". These criteria define actual requirements that a place must meet in order to be considered accessible.
+
+To evenly evaluate the physical world across different needs and disabilities, we cluster criteria into **TOPICS**, such as e.g. "Mobility", "Visual", "Auditory". So, we can say that a place is accessible for people with mobility impairments if it meets all criteria in the "Mobility" topic.
+
+The actual relation between criteria and topics happens individually for each category at the very bottom of the category tree. So, we can define for each sub-category which criteria must be met in each topic in order for this topic to be evaluated as accessible. To stay with the restaurant example, in order to be accessible in the "Visual" topic, a restaurant must meet the criteria "has a digital menu" and "has a tactile guidance system". While "has a digital menu" is a good criterion for a restaurant, it is not relevant for a public transport stop. By assigning criteria to a sub category and grouping them by topics, we can ensure that the evaluation is contextually relevant and meaningful. It also allows us to give actionable advice. When the score for the "has a digital menu" criterion for "restaurants" in a region is low, we can recommend restaurants to add a digital menu to improve accessibility for people with visual impairments.
+
+The examples made in this text are purely illustrative and do not reflect the actual criteria, topics or categories that will be used in the a11y-Score algorithm. We decided to define and refine those incrementally as we move forward and as we gain more data from research, analysis and feedback.
+
+## Consequences
+By splitting the accessibility of the physical world into categories, sub categories, criteria and topics, we create a structured and manageable way to evaluate accessibility at a small level and then aggregate it to a larger level. We can use this structure to add weights to criteria and categories to further refine the scoring algorithm.
+
+The downside of this structure is, that instead of calculating a single score/datapoint, we need to calculate and save a score for each combination of criterion/topic/category, increasing the periodically generated data volume. However, this is a necessary trade-off to ensure that we can provide actionable insights and recommendations for improving accessibility.
+
+Another downside is, that there are plenty of criteria to assess the accessibility of a place, which makes it nearly impossible to evaluate all of them at once. We will need to prioritize which criteria are most important and focus on those first, iteratively adding more criteria as we go along. This will probably lead to less accurate results in the beginning, but it allows us to gather feedback and refine our criteria based on real-world data and user input.

--- a/docs/architecture/decisions/004-scoring-algorithm-design.md
+++ b/docs/architecture/decisions/004-scoring-algorithm-design.md
@@ -1,0 +1,54 @@
+# ADR 4 - Scoring Algorithm Design
+
+## Status
+✅ Accepted on 2025-07-21
+
+## Context
+Open Street Map as our primary data source offers a wide range of information on places all around the world. In order to aggregate available accessibility-relevant details into a comparable score (a single number), it is crucial to group relevant tags into clusters, as well as to define a method how to process and weigh the data points into meaningful values by respecting factors like varying importance and missing data.
+
+## Decision
+
+### Criteria Score
+
+#### Scoring
+As established in ADR 3, the algorithm breaks down the accessibility of the physical world using a tree of _categories_ (e.g. food & drinks), where each _sub-category_ (e.g. restaurant) has a list of _criteria_ (e.g. wheelchair-accessible) grouped into _topics_ (.e.g. mobility). 
+
+Each criterium directly corresponds to a calculation based on OSM tags and their values - for now - and translates into a numeric single score of integer values (points).
+
+A score of 100 points for a criterium means, we consider a place to be fully accessible for that specific criterium. However, we include the possibility to have a score of more than 100 points in order to be able to reward outstanding efforts if special features are present, e.g. "Changing Place" toilets.
+
+Depending on the nature of the OSM tags used, the scores of single places/geometries within a criterium will be averaged. We choose either median (in case of counts that should not be sensitive to outliers) or arithmetic mean (in case of lengths, areas or outlier sensitive counts) for averaging.
+
+#### Selection
+For the first version of the score we will focus only on existing OSM tags and only on those that can be translated into numeric values in a straightforward way. For example, we will use the "wheelchair" and the "blind" tag since their values can only be "yes", "limited", "no", if tagged correctly. The strings can then be translated into points, e.g. yes => 100 points, limited => 50 points, no => 10 points.
+
+> [!NOTE]
+> This incentivizes the mere presence of a tag by giving at least some positive number of points for each value. Zero points will be given if a tag is missing entirely or tagged wrongly.
+
+> [!NOTE]
+> For the first version we will omit tags for which scoring is more complex, e.g. entrances since they require bundling of multiple semantically overlapping tags, or surfaces since they require computation of areas.
+
+### Topic Score
+All individual criteria scores within a topic for a given category will be aggregated into a single topic score. This will be done by applying weights to each individual criterium within a given topic. For example: in the "mobility" topic, the "wheelchair-accessibility" criterium should probably be weighted more heavily than the "accepts-credit-cards" criterium.
+
+### Sub-Category Score
+To compute the sub-category score, all individual topic scores will be determined and averaged. Since the topics correspond to different groups of accessibility needs, there will be no weighing factors applied for averaging.
+
+### Category Score
+The scores of all sub-categories are compiled in a weighted average to form an overall score of the category.
+
+### Region Score
+Finally, the scores of all categories are compiled into an overall score for the region by a weighted average.
+
+The examples made in this text are purely illustrative and do not reflect the actual criteria, topics, categories, OSM-tags, weights or point values that will be used in the a11y-Score algorithm. We decided to define and refine those incrementally as we move forward and as we gain more data from research, analysis and feedback.
+
+## Consequences
+
+We decided to use a points/integer based scoring system instead of percentages. This means we need to explain the point system to users more thoroughly, as it is not as intuitive as percentages. We strongly believe an arbitrary point system is better suited to score the accessibility as a percentage based score could lead to a lot of preconceptions.
+
+The scoring algorithm includes a lot of weighting factors, which will allow us to adjust the importance of different criteria and categories over time. We will need to very carefully choose these weights and adjust them based on user-feedback and future research. In order to make the algorithm transparent and understandable, we also need to document all weights and the reasoning for them in detail.
+
+For the MVP and the first couple of versions of the algorithm, we decided to initially omit certain tags and not include complex criteria which may lead to an incomplete picture of accessibility, but enables quick implementation and fast iterations.
+
+The reliance on data from Open Street Map could introduce biases if the data is incomplete or varies significantly between regions, leading to skewed scores. To cater that, this scoring mechanism is designed to encourage users to accurately reflect the accessibility features of their locations by incentivizing tagging (a negative tag gets more points than a missing tag). To further mitigate this, we need to work with population data and thresholds for data quality in the future. 
+


### PR DESCRIPTION
This combines https://github.com/sozialhelden/a11yscore/pull/3 and https://github.com/sozialhelden/a11yscore/pull/2, adding ADR 3 and 4, including feedback and input from @opyh, @Mayaryin and me.

The introduction part in ADR 4 with explanation of the taxonomy has been replaced with a reference to ADR 3. Also the selection and scoring of criteria have been separated to make it more clear. The part about weighting by population data and capacity has been removed, as ADR 5 will tackle this topic. I also added some additional consequences to ADR 4.