### PR TITLE
feat: add italian cities to sync job

### DIFF
--- a/src/a11yscore/config/admin-areas.ts
+++ b/src/a11yscore/config/admin-areas.ts
@@ -19,7 +19,10 @@ export const includedItalianCities = [
   // We temporarily include Rom, Venedig, Florenz, Mailand, Neapel for an event in the Italian consulate
   -41485, // Rome
   -44741, // Venice
+  -43648, // State Veneto
   -42602, // Florence
   -44915, // Milan
+  -44879, // State Lombardy
   -40767, // Naples
+  -42856, // Bologna
 ];

--- a/src/a11yscore/config/admin-areas.ts
+++ b/src/a11yscore/config/admin-areas.ts
@@ -1,5 +1,6 @@
 export const allowedCountries = [
   -51477, // Germany
+  -365331,
 ];
 
 export const allowedAdminLevels = [
@@ -12,4 +13,13 @@ export const excludedAdminAreas = [
   // Country of Bremen, includes Bremerhaven.
   // We exclude this to avoid duplicate with Bremen City and Bremerhaven City
   -62718,
+];
+
+export const includedItalianCities = [
+  // We temporarily include Rom, Venedig, Florenz, Mailand, Neapel for an event in the Italian consulate
+  -41485, // Rome
+  -44741, // Venice
+  -42602, // Florence
+  -44915, // Milan
+  -40767, // Naples
 ];

--- a/src/a11yscore/jobs/sync-admin-areas.ts
+++ b/src/a11yscore/jobs/sync-admin-areas.ts
@@ -7,6 +7,7 @@ import { scoreQueue, setAdminAreaImageJobId } from "~/queue";
 import {
   allowedAdminLevels,
   allowedCountries,
+  includedItalianCities,
 } from "~~/src/a11yscore/config/admin-areas";
 
 // extend slug to handle German characters properly
@@ -26,14 +27,21 @@ export async function handle() {
     JOIN ${osm_admin_gen0} ON ${osm_admin_gen0.osm_id} IN ${allowedCountries}
     WHERE 
         ST_Covers(
-            ${osm_admin_gen0.geometry},
+                ${osm_admin_gen0.geometry},
             -- Checking only for a representative point inside the sub-region avoids
             -- missing sub-regions with exclaves and non-exact border topologies (like
             -- Bavaria in Germany). 
-            ST_PointOnSurface(${osm_admin.geometry})
+                ST_PointOnSurface(${osm_admin.geometry})
         )
-        AND ${osm_admin.admin_level} IN ${allowedAdminLevels}
+        AND ${osm_admin.admin_level} IN ${allowedAdminLevels} 
         AND ${osm_admin.name} != ''
+      
+    UNION
+
+    SELECT ${osm_admin.osm_id}, ${osm_admin.name}, ${osm_admin.admin_level}, ${osm_admin.wikidata}    
+    FROM ${osm_admin}    
+    WHERE ${osm_admin.osm_id} IN ${includedItalianCities}      
+      AND ${osm_admin.name} != ''
   `;
 
   const { rows } = await osmSyncDb.execute<AdminAreaResult>(query);


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**
For an event at the italian consulate we temporarily inclue 5 italian cities to the score.
